### PR TITLE
Add thread starring and fix sendEmail replyTo handling

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,196 +2,198 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-    provider = "prisma-client-js"
+  provider = "prisma-client-js"
 }
 
 datasource db {
-    provider = "postgresql"
-    url      = env("DATABASE_URL")
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 model User {
-    id           String  @id @default(cuid())
-    emailAddress String  @unique
-    firstName    String?
-    lastName     String?
-    imageUrl     String?
+  id           String  @id @default(cuid())
+  emailAddress String  @unique
+  firstName    String?
+  lastName     String?
+  imageUrl     String?
 
-    stripeSubscriptionId String?             @unique
-    stripeSubscription   StripeSubscription? @relation(fields: [stripeSubscriptionId], references: [id])
+  stripeSubscriptionId String?             @unique
+  stripeSubscription   StripeSubscription? @relation(fields: [stripeSubscriptionId], references: [id])
 
-    role Role @default(user)
+  role Role @default(user)
 
-    accounts Account[]
+  accounts Account[]
 
-    chatbotInteraction ChatbotInteraction?
+  chatbotInteraction ChatbotInteraction?
 }
 
 enum Role {
-    user
-    admin
+  user
+  admin
 }
 
 model ChatbotInteraction {
-    id String @id @default(cuid())
+  id String @id @default(cuid())
 
-    day   String
-    count Int    @default(1)
+  day   String
+  count Int    @default(1)
 
-    userId String? @unique
-    user   User?   @relation(fields: [userId], references: [id])
+  userId String? @unique
+  user   User?   @relation(fields: [userId], references: [id])
 
-    @@unique([day, userId])
-    @@index([day, userId])
+  @@unique([day, userId])
+  @@index([day, userId])
 }
 
 model StripeSubscription {
-    id        String   @id @default(cuid())
-    createdAt DateTime @default(now())
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
 
-    userId String? @unique
-    user   User?
+  userId String? @unique
+  user   User?
 
-    subscriptionId String? @unique
-    productId      String?
-    priceId        String?
-    customerId     String?
+  subscriptionId String? @unique
+  productId      String?
+  priceId        String?
+  customerId     String?
 
-    currentPeriodEnd DateTime
-    updatedAt        DateTime @updatedAt
+  currentPeriodEnd DateTime
+  updatedAt        DateTime @updatedAt
 }
 
 model Account {
-    id     String @id @default(cuid())
-    userId String
+  id     String @id @default(cuid())
+  userId String
 
-    binaryIndex Json?
+  binaryIndex Json?
 
-    token        String @unique
-    provider     String
-    emailAddress String
-    name         String
+  token        String @unique
+  provider     String
+  emailAddress String
+  name         String
 
-    nextDeltaToken String?
+  nextDeltaToken String?
 
-    user           User           @relation(fields: [userId], references: [id])
-    threads        Thread[]
-    emailAddresses EmailAddress[]
+  user           User           @relation(fields: [userId], references: [id])
+  threads        Thread[]
+  emailAddresses EmailAddress[]
 }
 
 //     // "dev": "next dev --turbo | egrep -v '^\\s?(GET|POST|OPTIONS)'",
 
 model Thread {
-    id              String   @id @default(cuid())
-    subject         String
-    lastMessageDate DateTime
-    participantIds  String[]
-    accountId       String
-    account         Account  @relation(fields: [accountId], references: [id])
+  id              String   @id @default(cuid())
+  subject         String
+  lastMessageDate DateTime
+  participantIds  String[]
+  accountId       String
+  account         Account  @relation(fields: [accountId], references: [id])
 
-    done Boolean @default(false)
+  done Boolean @default(false)
 
-    inboxStatus Boolean @default(true)
-    draftStatus Boolean @default(false)
-    sentStatus  Boolean @default(false)
+  inboxStatus Boolean @default(true)
+  draftStatus Boolean @default(false)
+  sentStatus  Boolean @default(false)
+  starred     Boolean @default(false)
 
-    emails Email[]
+  emails Email[]
 
-    @@index([accountId])
-    @@index([done])
-    @@index([inboxStatus])
-    @@index([draftStatus])
-    @@index([sentStatus])
-    @@index([lastMessageDate])
+  @@index([accountId])
+  @@index([done])
+  @@index([inboxStatus])
+  @@index([draftStatus])
+  @@index([sentStatus])
+  @@index([starred])
+  @@index([lastMessageDate])
 }
 
 model Email {
-    id                   String                @id @default(cuid())
-    threadId             String
-    thread               Thread                @relation(fields: [threadId], references: [id])
-    createdTime          DateTime
-    lastModifiedTime     DateTime
-    sentAt               DateTime
-    receivedAt           DateTime
-    internetMessageId    String
-    subject              String
-    sysLabels            String[]
-    keywords             String[]
-    sysClassifications   String[]
-    sensitivity          Sensitivity           @default(normal)
-    meetingMessageMethod MeetingMessageMethod?
-    from                 EmailAddress          @relation("FromEmail", fields: [fromId], references: [id])
-    fromId               String
-    to                   EmailAddress[]        @relation("ToEmails")
-    cc                   EmailAddress[]        @relation("CcEmails")
-    bcc                  EmailAddress[]        @relation("BccEmails")
-    replyTo              EmailAddress[]        @relation("ReplyToEmails")
-    hasAttachments       Boolean
-    body                 String?
-    bodySnippet          String?
-    attachments          EmailAttachment[]
-    inReplyTo            String?
-    references           String?
-    threadIndex          String?
-    internetHeaders      Json[]
-    nativeProperties     Json?
-    folderId             String?
-    omitted              String[]
+  id                   String                @id @default(cuid())
+  threadId             String
+  thread               Thread                @relation(fields: [threadId], references: [id])
+  createdTime          DateTime
+  lastModifiedTime     DateTime
+  sentAt               DateTime
+  receivedAt           DateTime
+  internetMessageId    String
+  subject              String
+  sysLabels            String[]
+  keywords             String[]
+  sysClassifications   String[]
+  sensitivity          Sensitivity           @default(normal)
+  meetingMessageMethod MeetingMessageMethod?
+  from                 EmailAddress          @relation("FromEmail", fields: [fromId], references: [id])
+  fromId               String
+  to                   EmailAddress[]        @relation("ToEmails")
+  cc                   EmailAddress[]        @relation("CcEmails")
+  bcc                  EmailAddress[]        @relation("BccEmails")
+  replyTo              EmailAddress[]        @relation("ReplyToEmails")
+  hasAttachments       Boolean
+  body                 String?
+  bodySnippet          String?
+  attachments          EmailAttachment[]
+  inReplyTo            String?
+  references           String?
+  threadIndex          String?
+  internetHeaders      Json[]
+  nativeProperties     Json?
+  folderId             String?
+  omitted              String[]
 
-    emailLabel EmailLabel @default(inbox)
+  emailLabel EmailLabel @default(inbox)
 
-    @@index([threadId])
-    @@index([emailLabel])
-    @@index([sentAt])
+  @@index([threadId])
+  @@index([emailLabel])
+  @@index([sentAt])
 }
 
 enum EmailLabel {
-    inbox
-    sent
-    draft
+  inbox
+  sent
+  draft
 }
 
 model EmailAddress {
-    id            String  @id @default(cuid())
-    name          String?
-    address       String
-    raw           String?
-    sentEmails    Email[] @relation("FromEmail")
-    receivedTo    Email[] @relation("ToEmails")
-    receivedCc    Email[] @relation("CcEmails")
-    receivedBcc   Email[] @relation("BccEmails")
-    replyToEmails Email[] @relation("ReplyToEmails")
+  id            String  @id @default(cuid())
+  name          String?
+  address       String
+  raw           String?
+  sentEmails    Email[] @relation("FromEmail")
+  receivedTo    Email[] @relation("ToEmails")
+  receivedCc    Email[] @relation("CcEmails")
+  receivedBcc   Email[] @relation("BccEmails")
+  replyToEmails Email[] @relation("ReplyToEmails")
 
-    accountId String
-    account   Account @relation(fields: [accountId], references: [id])
+  accountId String
+  account   Account @relation(fields: [accountId], references: [id])
 
-    @@unique([accountId, address])
+  @@unique([accountId, address])
 }
 
 model EmailAttachment {
-    id              String  @id @default(cuid())
-    name            String
-    mimeType        String
-    size            Int
-    inline          Boolean
-    contentId       String?
-    content         String?
-    contentLocation String?
-    Email           Email   @relation(fields: [emailId], references: [id])
-    emailId         String
+  id              String  @id @default(cuid())
+  name            String
+  mimeType        String
+  size            Int
+  inline          Boolean
+  contentId       String?
+  content         String?
+  contentLocation String?
+  Email           Email   @relation(fields: [emailId], references: [id])
+  emailId         String
 }
 
 enum Sensitivity {
-    normal
-    private
-    personal
-    confidential
+  normal
+  private
+  personal
+  confidential
 }
 
 enum MeetingMessageMethod {
-    request
-    reply
-    cancel
-    counter
-    other
+  request
+  reply
+  cancel
+  counter
+  other
 }

--- a/src/lib/account.ts
+++ b/src/lib/account.ts
@@ -194,7 +194,7 @@ class Account {
                     to,
                     cc,
                     bcc,
-                    replyTo: [replyTo],
+                    ...(replyTo ? { replyTo: [replyTo] } : {}),
                 },
                 {
                     params: {

--- a/src/server/api/routers/mail.tsx
+++ b/src/server/api/routers/mail.tsx
@@ -267,6 +267,28 @@ export const mailRouter = createTRPCRouter({
             })
         }
     }),
+    starThread: protectedProcedure.input(z.object({
+        threadId: z.string(),
+        accountId: z.string()
+    })).mutation(async ({ ctx, input }) => {
+        const account = await authoriseAccountAccess(input.accountId, ctx.auth.userId)
+        if (!account) throw new Error("Invalid token")
+        await ctx.db.thread.update({
+            where: { id: input.threadId },
+            data: { starred: true }
+        })
+    }),
+    unstarThread: protectedProcedure.input(z.object({
+        threadId: z.string(),
+        accountId: z.string()
+    })).mutation(async ({ ctx, input }) => {
+        const account = await authoriseAccountAccess(input.accountId, ctx.auth.userId)
+        if (!account) throw new Error("Invalid token")
+        await ctx.db.thread.update({
+            where: { id: input.threadId },
+            data: { starred: false }
+        })
+    }),
     getEmailDetails: protectedProcedure.input(z.object({
         emailId: z.string(),
         accountId: z.string()


### PR DESCRIPTION
## Summary
- allow starring threads
- fix sendEmail so replyTo is optional
- include starThread/unstarThread procedures
- add `starred` field in Prisma schema

## Testing
- `npx prisma format`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ecfcb6888331a6daf21b6709b373